### PR TITLE
fix:weight_type missing when create document in dataset (#16503)

### DIFF
--- a/api/fields/dataset_fields.py
+++ b/api/fields/dataset_fields.py
@@ -24,6 +24,7 @@ vector_setting_fields = {
 }
 
 weighted_score_fields = {
+    "weight_type": fields.String,
     "keyword_setting": fields.Nested(keyword_setting_fields),
     "vector_setting": fields.Nested(vector_setting_fields),
 }

--- a/web/app/components/workflow/nodes/knowledge-retrieval/types.ts
+++ b/web/app/components/workflow/nodes/knowledge-retrieval/types.ts
@@ -10,6 +10,7 @@ import type {
   DataSet,
   MetadataInDoc,
   RerankingModeEnum,
+  WeightedScoreEnum,
 } from '@/models/datasets'
 
 export type MultipleRetrievalConfig = {
@@ -21,6 +22,7 @@ export type MultipleRetrievalConfig = {
   }
   reranking_mode?: RerankingModeEnum
   weights?: {
+    weight_type: WeightedScoreEnum
     vector_setting: {
       vector_weight: number
       embedding_provider_name: string

--- a/web/models/debug.ts
+++ b/web/models/debug.ts
@@ -1,6 +1,7 @@
 import type { AgentStrategy, ModelModeType, RETRIEVE_TYPE, ToolItem, TtsAutoPlay } from '@/types/app'
 import type {
   RerankingModeEnum,
+  WeightedScoreEnum,
 } from '@/models/datasets'
 import type { FileUpload } from '@/app/components/base/features/types'
 import type {
@@ -165,6 +166,7 @@ export type DatasetConfigs = {
   }
   reranking_mode?: RerankingModeEnum
   weights?: {
+    weight_type: WeightedScoreEnum
     vector_setting: {
       vector_weight: number
       embedding_provider_name: string


### PR DESCRIPTION
# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

